### PR TITLE
Require the HTTP config file on all OS.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,10 +46,8 @@ class horizon(
   # I am totally confused by this, I do not think it should be installed...
   if($::osfamily == 'Debian') {
     package { 'node-less': }
-  } elsif($::osfamily == 'Redhat') {
-    # add a file resource for the vhost to ensure if does not get purged
-    file { '/etc/httpd/conf.d/openstack-dashboard.conf':}
   }
+  file { $::horizon::params::httpd_config_file:}
 
   Service <| title == 'memcached' |> -> Class['horizon']
 


### PR DESCRIPTION
This is required on newer versions of puppet otherwise it will automatically remove the file.
