### PR TITLE
changed configuration to use apache vhost, added listen_plain option.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,8 +10,6 @@ class horizon::params {
       $http_modwsgi                = 'mod_wsgi'
       $package_name                = 'openstack-dashboard'
       $config_file                 = '/etc/openstack-dashboard/local_settings'
-      $httpd_config_file           = '/etc/httpd/conf.d/openstack-dashboard.conf'
-      $httpd_listen_config_file    = '/etc/httpd/conf/httpd.conf'
       $root_url                    = '/dashboard'
       $apache_user                 = 'apache'
       $apache_group                = 'apache'
@@ -19,8 +17,6 @@ class horizon::params {
     'Debian': {
       $http_service                = 'apache2'
       $config_file                 = '/etc/openstack-dashboard/local_settings.py'
-      $httpd_config_file           = '/etc/apache2/conf.d/openstack-dashboard.conf'
-      $httpd_listen_config_file    = '/etc/apache2/ports.conf'
       $root_url                    = '/horizon'
       $apache_user                 = 'horizon'
       $apache_group                = 'horizon'


### PR DESCRIPTION
changed all the configuration to use apache::vhost instead of the manual
file_line configs. also disabled all modules by default, and enable only
the required ones.

the changes keep the same interface, so it should be compatible with
previous versions of the module. there's a new argument though,
listen_plain, which defaults to true - this helps for deployments
wanting to disable non-ssl access.
