### PR TITLE
Add selection of Django session engine to this module

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,10 @@
 #    https on public sites. See: http://docs.openstack.org/developer/horizon/topics/deployment.html#secure-site-recommendations
 #    Defaults to false
 #
+#  [*django_session_engine*]
+#    (optional) Selects the session engine for Django to use.
+#    Defaults to undefined - will not add entry to local settings.
+#
 # === Deprecation notes
 #
 # If any value is provided for keystone_scheme, keystone_host, or
@@ -229,6 +233,7 @@ class horizon(
   $keystone_scheme         = undef,
   $vhost_extra_params      = undef,
   $secure_cookies          = false,
+  $django_session_engine   = undef,
 ) {
 
   include ::horizon::params

--- a/spec/classes/horizon_init_spec.rb
+++ b/spec/classes/horizon_init_spec.rb
@@ -63,6 +63,12 @@ describe 'horizon' do
           'COMPRESS_OFFLINE = True',
           "FILE_UPLOAD_TEMP_DIR = '/tmp'"
         ])
+        
+        # From internals of verify_contents, get the contents to check for absence of a line
+        content = subject.resource('file', platforms_params[:config_file]).send(:parameters)[:content]
+        
+        # With default options, should _not_ have a line to configure SESSION_ENGINE
+        content.should_not match(/^SESSION_ENGINE/)
       end
     end
 
@@ -70,6 +76,7 @@ describe 'horizon' do
       before do
         params.merge!({
           :cache_server_ip         => '10.0.0.1',
+          :django_session_engine   => 'django.contrib.sessions.backends.cache',
           :keystone_default_role   => 'SwiftOperator',
           :keystone_url            => 'https://keystone.example.com:4682',
           :openstack_endpoint_type => 'internalURL',
@@ -92,6 +99,7 @@ describe 'horizon' do
           'SESSION_COOKIE_SECURE = True',
           "SECRET_KEY = 'elj1IWiLoWHgcyYxFVLj7cM5rGOOxWl0'",
           "        'LOCATION': '10.0.0.1:11211',",
+          'SESSION_ENGINE = "django.contrib.sessions.backends.cache"',
           'OPENSTACK_KEYSTONE_URL = "https://keystone.example.com:4682"',
           'OPENSTACK_KEYSTONE_DEFAULT_ROLE = "SwiftOperator"',
           "    'can_set_mount_point': False,",
@@ -106,7 +114,7 @@ describe 'horizon' do
           'SECONDARY_ENDPOINT_TYPE = "ANY-VALUE"',
           'API_RESULT_LIMIT = 4682',
           'COMPRESS_OFFLINE = False',
-          "FILE_UPLOAD_TEMP_DIR = '/var/spool/horizon'",
+          "FILE_UPLOAD_TEMP_DIR = '/var/spool/horizon'"
         ])
       end
 

--- a/templates/local_settings.py.erb
+++ b/templates/local_settings.py.erb
@@ -129,6 +129,12 @@ CACHES = {
     }
 }
 
+# Configure session backend if set.
+# This allows us to switch to a different session backend to fit infrastructure
+# and/or security preferences.
+<% if @django_session_engine %>
+SESSION_ENGINE = "<%= @django_session_engine %>"
+<% end %>
 
 # Send email to the console by default
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
This allows Django to be set to use something other than the default session engine through Puppet. By default, it will have no impact on existing configurations.

We've added this because our security constraints make signed cookies as a session store for Horizon undesirable. The reasons for this are:
- Sessions become vulnerable to replay attacks, a clean log-out is difficult to achieve.
- Serialising sessions in cookies may allow an attacker to escalate read-only access to server configuration in to code execution via deserialisation of attacker-generated content.
