### PR TITLE
Add support for 'Retrieve Password' via Horizon UI

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -266,6 +266,10 @@
 #    (optional) The default theme to use from list of available themes. Value should be theme_name.
 #    Defaults to false
 #
+#  [*password_retrieve*]
+#     (optional) Enables the use of 'Retrieve Password' in the Horizon Web UI.
+#     Defaults to false
+#
 # === DEPRECATED group/name
 #
 #  [*fqdn*]
@@ -359,6 +363,7 @@ class horizon(
   $vhost_extra_params                  = undef,
   $available_themes                    = false,
   $default_theme                       = false,
+  $password_retrieve                   = false,
   # DEPRECATED PARAMETERS
   $custom_theme_path                   = undef,
   $fqdn                                = undef,

--- a/templates/local_settings.py.erb
+++ b/templates/local_settings.py.erb
@@ -286,6 +286,9 @@ OPENSTACK_KEYSTONE_BACKEND = {
 # Setting this to True, will add a new "Retrieve Password" action on instance,
 # allowing Admin session password retrieval/decryption.
 #OPENSTACK_ENABLE_PASSWORD_RETRIEVE = False
+<% if @password_retrieve %>
+OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True
+<%end -%>
 
 # The Launch Instance user experience has been significantly enhanced.
 # You can choose whether to enable the new launch instance experience,


### PR DESCRIPTION
In local_settings.py.erb this value was hardcoded to false.
This change enables the setting of this value as referenced in
https://review.openstack.org/#/c/61032/